### PR TITLE
Use autogenerated parameter info for templates without TemplateData

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -2517,6 +2517,7 @@
 			"modules/ve-mw/tests/dm/ve.dm.mwExample.js",
 			"modules/ve-mw/tests/dm/ve.dm.Converter.test.js",
 			"modules/ve-mw/tests/dm/ve.dm.MWImageModel.test.js",
+			"modules/ve-mw/tests/dm/ve.dm.MWTransclusionModel.test.js",
 			"modules/ve-mw/tests/dm/ve.dm.MWInternalLinkAnnotation.test.js",
 			"lib/ve/tests/ce/ve.ce.test.js",
 			"lib/ve/tests/ce/ve.ce.Document.test.js",

--- a/modules/ve-mw/dm/models/ve.dm.MWTransclusionModel.js
+++ b/modules/ve-mw/dm/models/ve.dm.MWTransclusionModel.js
@@ -325,8 +325,9 @@
 					missingTitle = {};
 					missingTitle[ title ] = { missing: true };
 					ve.init.platform.linkCache.setMissing( missingTitle );
-				} else if ( data.pages[ id ].notemplatedata ) {
-					// Prevent asking again for templates that have no specs
+				} else if ( data.pages[ id ].notemplatedata && !OO.isPlainObject( data.pages[ id ].params ) ) {
+					// (T243868) Prevent asking again for templates that have neither user-provided specs
+					// nor automatically detected params
 					specs[ title ] = null;
 				} else {
 					specs[ title ] = data.pages[ id ];

--- a/modules/ve-mw/tests/dm/ve.dm.MWTransclusionModel.test.js
+++ b/modules/ve-mw/tests/dm/ve.dm.MWTransclusionModel.test.js
@@ -1,0 +1,122 @@
+/*!
+ * VisualEditor DataModel MWTransclusionModel tests.
+ *
+ * @copyright 2011-2020 VisualEditor Team and others; see http://ve.mit-license.org
+ */
+
+( function () {
+	QUnit.module( 've.dm.MWTransclusionModel', QUnit.newMwEnvironment( {
+		setup: function () {
+			// Mock XHR for mw.Api()
+			this.server = this.sandbox.useFakeServer();
+			this.server.respondImmediately = true;
+
+			ve.test.utils.mwEnvironment.setup.call( this );
+		},
+		teardown: function () {
+			ve.test.utils.mwEnvironment.teardown.call( this );
+		}
+	} ) );
+
+	function runAddPartTest( assert, name, response, server, callback ) {
+		var doc = ve.dm.Document.static.newBlankDocument(),
+			transclusion = new ve.dm.MWTransclusionModel( doc ),
+			part = ve.dm.MWTemplateModel.newFromName( transclusion, name ),
+			done = assert.async();
+
+		server.respondWith( [ 200, { 'Content-Type': 'application/json' }, JSON.stringify( response ) ] );
+
+		transclusion.addPart( part )
+			.then( function () {
+				callback( transclusion );
+			} )
+			.always( function () {
+				done();
+			} );
+	}
+
+	QUnit.test( 'fetch template part data', function ( assert ) {
+		var response = {
+			batchcomplete: '',
+			pages: {
+				1331311: {
+					title: 'Template:Test',
+					description: { en: 'MWTransclusionModel template test' },
+					params: {
+						test: {
+							label: { en: 'Test param' },
+							type: 'string',
+							description: { en: 'This is a test param' },
+							required: false,
+							suggested: false,
+							example: null,
+							deprecated: false,
+							aliases: [],
+							autovalue: null,
+							default: null
+						}
+					},
+					paramOrder: [ 'test' ],
+					format: 'inline',
+					sets: [],
+					maps: {}
+				}
+			}
+		};
+
+		runAddPartTest( assert, 'Test', response, this.server, function ( transclusion ) {
+			var parts = transclusion.getParts(),
+				spec = parts[ 0 ].getSpec();
+
+			assert.strictEqual( parts.length, 1 );
+			assert.strictEqual( spec.getDescription( 'en' ), 'MWTransclusionModel template test' );
+			assert.strictEqual( spec.getParameterLabel( 'test', 'en' ), 'Test param' );
+		} );
+	} );
+
+	// T243868
+	QUnit.test( 'fetch part data for parameterized template with no TemplateData', function ( assert ) {
+		var response = {
+			batchcomplete: '',
+			pages: {
+				1331311: {
+					title: 'Template:NoData',
+					notemplatedata: true,
+					params: {
+						foo: [],
+						bar: []
+					}
+				}
+			}
+		};
+
+		runAddPartTest( assert, 'NoData', response, this.server, function ( transclusion ) {
+			var parts = transclusion.getParts(),
+				spec = parts[ 0 ].getSpec();
+
+			assert.strictEqual( parts.length, 1 );
+			assert.deepEqual( spec.getParameterNames(), [ 'foo', 'bar' ] );
+		} );
+	} );
+
+	QUnit.test( 'fetch part data for template with no TemplateData and no params', function ( assert ) {
+		var response = {
+			batchcomplete: '',
+			pages: {
+				1331311: {
+					title: 'Template:NoParams',
+					notemplatedata: true,
+					params: []
+				}
+			}
+		};
+
+		runAddPartTest( assert, 'NoParams', response, this.server, function ( transclusion ) {
+			var parts = transclusion.getParts(),
+				spec = parts[ 0 ].getSpec();
+
+			assert.strictEqual( parts.length, 1 );
+			assert.deepEqual( spec.getParameterNames(), [] );
+		} );
+	} );
+}() );


### PR DESCRIPTION
When a template does not have user-provided TemplateData documentation,
the TemplateData API falls back to extracting possible parameters from the raw wikitext
to generate an API response with a list of potential parameters. However, it also
sets the "notemplatedata" field in the response, causing the VisualEditor to think
the response contains no useful information and ignore it. This appears to have been
an unintended side-effect of I97a1bfc9f9ead082a673a91b9d2053630a90309c.

This patch ensures that the VisualEditor will correctly consider such responses from
TemplateData by modifying ve.dm.MWTransclusionModel to check if the response contains
a parameter map. Some unit tests were added for the class to verify this behavior.

Bug: T243868
Change-Id: I72005880d9301a53224473900efe2917379e8708