### PR TITLE
IW-4008 | Add a hook to allow extensions to disable/enable the VE

### DIFF
--- a/includes/VisualEditorHooks.php
+++ b/includes/VisualEditorHooks.php
@@ -257,7 +257,11 @@ class VisualEditorHooks {
 			return true;
 		}
 
-		if ( self::isSupportedEditPage( $title, $user, $req ) ) {
+		// Fandom change: Add a hook to let extensions disable the VE on a per-page basis
+		if (
+			Hooks::run( 'VisualEditorSupportedEditPage', [ $article->getContext() ] ) &&
+			self::isSupportedEditPage( $title, $user, $req )
+		) {
 			$params = $req->getValues();
 			$params['venoscript'] = '1';
 			$url = wfScript() . '?' . wfArrayToCgi( $params );

--- a/modules/ve-mw/init/targets/ve.init.mw.DesktopArticleTarget.init.js
+++ b/modules/ve-mw/init/targets/ve.init.mw.DesktopArticleTarget.init.js
@@ -991,7 +991,10 @@
 
 		// Not on the edit conflict page of the TwoColumnConflict extension (T156251)
 		// TODO: Allow the TwoColumnConflict extension to do this itself (T174180)
-		mw.config.get( 'wgTwoColConflict' ) !== 'true'
+		mw.config.get( 'wgTwoColConflict' ) !== 'true' &&
+
+		// Fandom change: Not on portable infobox templates
+		!mw.config.get( 'wgIsPortableInfoboxTemplate' )
 	);
 
 	// Duplicated in VisualEditor.hooks.php#isVisualAvailable()


### PR DESCRIPTION
This will be used to disable the 2017 NWE on portable infobox pages.
Also update the FE logic to likewise disable VE initialization.