### PR TITLE
SECURITY: ve.ui.MWMediaDialog: Escape plaintext image metadata fields

### DIFF
--- a/modules/ve-mw/ui/dialogs/ve.ui.MWMediaDialog.js
+++ b/modules/ve-mw/ui/dialogs/ve.ui.MWMediaDialog.js
@@ -775,9 +775,9 @@ ve.ui.MWMediaDialog.prototype.cleanAPIresponse = function ( rawResponse, config 
 	}
 
 	// Check if the string should be truncated
-	return isTruncated && !config.ignoreCharLimit ?
-		originalText.substring( 0, charLimit ) + ellipsis :
-		originalText;
+	return mw.html.escape( isTruncated && !config.ignoreCharLimit ?
+		originalText.slice( 0, charLimit ) + ellipsis :
+		originalText );
 };
 
 /**


### PR DESCRIPTION
CVE-2021-44855

Bug: T293589
Change-Id: I691b4065e67c53c4276599c8d16c31ab5591db3a