### PR TITLE
CATS-2377 | Backport VisualEditorBeforeEditorHook

### DIFF
--- a/includes/VisualEditorBeforeEditorHook.php
+++ b/includes/VisualEditorBeforeEditorHook.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MediaWiki\Extension\VisualEditor;
+
+use OutputPage;
+use Skin;
+
+/**
+ * VisualEditorBeforeEditorHook
+ *
+ * @file
+ * @ingroup Extensions
+ * @copyright 2011-2021 VisualEditor Team and others; see AUTHORS.txt
+ * @license MIT
+ */
+
+interface VisualEditorBeforeEditorHook {
+
+	/**
+	 * This hook is executed in before deciding if the editor is available on a certain page
+	 *
+	 * If the hook returns false, the editor is not available.
+	 *
+	 * @param OutputPage $output
+	 * @param Skin $skin
+	 * @return bool
+	 */
+	public function onVisualEditorBeforeEditorHook(
+		OutputPage $output,
+		Skin $skin
+	): bool;
+
+}

--- a/includes/VisualEditorHookRunner.php
+++ b/includes/VisualEditorHookRunner.php
@@ -14,10 +14,13 @@ namespace MediaWiki\Extension\VisualEditor;
 use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Page\ProperPageIdentity;
 use MediaWiki\User\UserIdentity;
+use OutputPage;
+use Skin;
 
 class VisualEditorHookRunner implements
 	VisualEditorApiVisualEditorEditPreSaveHook,
-	VisualEditorApiVisualEditorEditPostSaveHook
+	VisualEditorApiVisualEditorEditPostSaveHook,
+	VisualEditorBeforeEditorHook
 {
 
 	public const SERVICE_NAME = 'VisualEditorHookRunner';
@@ -70,5 +73,16 @@ class VisualEditorHookRunner implements
 			$saveResult,
 			&$apiResponse
 		], [ 'abortable' => false ] );
+	}
+
+	/** @inheritDoc */
+	public function onVisualEditorBeforeEditorHook(
+		OutputPage $output,
+		Skin $skin
+	): bool {
+		return $this->hookContainer->run( 'VisualEditorBeforeEditorHook', [
+			$output,
+			$skin
+		], [ 'abortable' => true ] );
 	}
 }

--- a/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
+++ b/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
@@ -1148,18 +1148,17 @@
 	// Whether VisualEditor should be available for the current user, page, wiki, mediawiki skin,
 	// browser etc.
 	init.isAvailable = (
-		// Support check asserts that Array.prototype.indexOf is available so we can use it below
 		VisualEditorSupportCheck() &&
 
 		( ( 'vesupported' in uri.query ) || !$.client.test( init.unsupportedList, null, true ) ) &&
 
 		// Not on pages which are outputs of the Translate extensions
-		// TODO: Allow the Translate extension to do this itself (T174180)
+		// TODO: Remove this once the extension is using VisualEditorBeforeEditorHook (T174180)
 		mw.config.get( 'wgTranslatePageTranslation' ) !== 'translation' &&
 
-		// Not on the edit conflict page of the TwoColumnConflict extension (T156251)
-		// TODO: Allow the TwoColumnConflict extension to do this itself (T174180)
-		mw.config.get( 'wgTwoColConflict' ) !== 'true'
+		// Not on the editor in the FileImporter dialog (T298345)
+		// TODO: Remove this once the extension is using VisualEditorBeforeEditorHook (T174180)
+		!mw.config.get( 'wgFileImporterEditor' )
 	);
 
 	var enabledForUser = (


### PR DESCRIPTION
Upstream has introduced `VisualEditorBeforeEditorHook` that allows disabling the VE on selected pages. We need this functionality to e.g. disable the 2017 editor on portable infobox pages, so let's backport it and use it instead of our previous custom hook.