### PR TITLE
PLATFORM-7795 | Apply changes to MW 1.39 version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/ve"]
 	path = lib/ve
-	url = https://gerrit.wikimedia.org/r/VisualEditor/VisualEditor.git
+	url = https://github.com/wikimedia/visualeditor.git

--- a/modules/ve-mw/ce/nodes/ve.ce.MWBlockImageNode.js
+++ b/modules/ve-mw/ce/nodes/ve.ce.MWBlockImageNode.js
@@ -40,6 +40,8 @@ ve.ce.MWBlockImageNode = function VeCeMWBlockImageNode() {
 		$focusable = $missingImage;
 	} else {
 		$image = $( '<img>' )
+			.attr('loading', 'lazy')
+			.attr('decoding', 'async')
 			.attr( 'src', this.getResolvedAttribute( 'src' ) );
 		this.$a = $( '<a>' )
 			.attr( 'href', this.getResolvedAttribute( 'href' ) )


### PR DESCRIPTION
Backport our change to make the VE load images lazily as well as to use the GitHub mirror for cloning the nested `lib/ve` submodule.