### PR TITLE
[UGC 5375] Fixed sentry issue

### DIFF
--- a/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
+++ b/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
@@ -922,7 +922,8 @@
 				caVeEditNextnode =
 					( conf.tabPosition === 'before' ) ?
 						$caEdit.get( 0 ) :
-						$caEdit.next().get( 0 );
+						$caEdit.next().get( 0 ),
+				userCanEditOrViewSource = ($caEdit.length || $caSource.length);
 
 			if ( !$caVeEdit.length ) {
 				// The below duplicates the functionality of VisualEditorHooks::onSkinTemplateNavigation()
@@ -986,15 +987,19 @@
 			// If the edit tab is hidden, remove it.
 			if ( !( init.isVisualAvailable ) ) {
 				$caVeEdit.remove();
-			} else if ( pageCanLoadEditor ) {
+			} else if ( pageCanLoadEditor && userCanEditOrViewSource ) {
 				// Allow instant switching to edit mode, without refresh
 				$caVeEdit.off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
 				// FANDOM change
 				const pageSideEdit = $('.page-side-edit');
-				if (pageSideEdit[0].href.includes('veaction')) {
-					$('.page-side-edit').off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
-				} else {
-					$('.page-side-edit').off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'source' ) );
+				// There are cases when "edit" button is not rendered via PHP template since "edit" action is not present
+				// Which means that user doesn't have permissions to create / edit / view source of the page
+				if (pageSideEdit.length) {
+					if (pageSideEdit[0].href.includes('veaction')) {
+						$('.page-side-edit').off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
+					} else {
+						$('.page-side-edit').off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'source' ) );
+					}
 				}
 				$('.mw-editsection a:not(.mw-editsection-visualeditor)').off( '.ve-target' ).on( 'click.ve-target', init.onEditSectionLinkClick.bind( init, 'source' ) );
 
@@ -1029,11 +1034,11 @@
 				$('.page-side-edit').on('mouseover.ve-target-float', this.preloadModules.bind(this));
 				// FANDOM change
 			}
-			if ( pageCanLoadEditor ) {
+			if ( pageCanLoadEditor && userCanEditOrViewSource ) {
 				// Always bind "Edit source" tab, because we want to handle switching with changes
 				$caEdit.off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'source' ) );
 			}
-			if ( pageCanLoadEditor && init.isWikitextAvailable ) {
+			if ( pageCanLoadEditor && init.isWikitextAvailable && userCanEditOrViewSource ) {
 				// Only bind "Add topic" tab if NWE is available, because VE doesn't support section
 				// so we never have to switch from it when editing a section
 				$( '#ca-addsection' ).off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'source' ) );

--- a/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
+++ b/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
@@ -988,6 +988,7 @@
 			if ( !( init.isVisualAvailable ) ) {
 				$caVeEdit.remove();
 			} else if ( pageCanLoadEditor && userCanEditOrViewSource ) {
+				console.log('UGC-5375', pageCanLoadEditor, userCanEditOrViewSource);
 				// Allow instant switching to edit mode, without refresh
 				$caVeEdit.off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
 				// FANDOM change
@@ -995,6 +996,8 @@
 				// There are cases when "edit" button is not rendered via PHP template since "edit" action is not present
 				// Which means that user doesn't have permissions to create / edit / view source of the page
 				if (pageSideEdit.length) {
+					console.log('UGC-5375 - pageSideEditLength', pageSideEdit.length);
+					console.log('UGC-5375 - pageSideEdit[0]', pageSideEdit[0]);
 					if (pageSideEdit[0].href.includes('veaction')) {
 						$('.page-side-edit').off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
 					} else {
@@ -1013,10 +1016,12 @@
 							if (addedNode && addedNode.querySelector('[data-testid="highlight-action_edit-section"]')) {
 								this.preloadModules();
 								const editButton = addedNode.querySelector('[data-testid="highlight-action_edit-section"]');
-								if (pageSideEdit[0].href.includes('veaction')) {
-									editButton.addEventListener('click', init.onEditTabClick.bind(init, 'visual'));
-								} else {
-									editButton.addEventListener('click', init.onEditTabClick.bind(init, 'source'));
+								if (pageSideEdit.length) {
+									if (pageSideEdit[0].href.includes('veaction')) {
+										editButton.addEventListener('click', init.onEditTabClick.bind(init, 'visual'));
+									} else {
+										editButton.addEventListener('click', init.onEditTabClick.bind(init, 'source'));
+									}
 								}
 							}
 						}

--- a/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
+++ b/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
@@ -988,7 +988,6 @@
 			if ( !( init.isVisualAvailable ) ) {
 				$caVeEdit.remove();
 			} else if ( pageCanLoadEditor && userCanEditOrViewSource ) {
-				console.log('UGC-5375', pageCanLoadEditor, userCanEditOrViewSource);
 				// Allow instant switching to edit mode, without refresh
 				$caVeEdit.off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
 				// FANDOM change
@@ -996,8 +995,6 @@
 				// There are cases when "edit" button is not rendered via PHP template since "edit" action is not present
 				// Which means that user doesn't have permissions to create / edit / view source of the page
 				if (pageSideEdit.length) {
-					console.log('UGC-5375 - pageSideEditLength', pageSideEdit.length);
-					console.log('UGC-5375 - pageSideEdit[0]', pageSideEdit[0]);
 					if (pageSideEdit[0].href.includes('veaction')) {
 						$('.page-side-edit').off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
 					} else {

--- a/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
+++ b/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js
@@ -922,8 +922,7 @@
 				caVeEditNextnode =
 					( conf.tabPosition === 'before' ) ?
 						$caEdit.get( 0 ) :
-						$caEdit.next().get( 0 ),
-				userCanEditOrViewSource = ($caEdit.length || $caSource.length);
+						$caEdit.next().get( 0 );
 
 			if ( !$caVeEdit.length ) {
 				// The below duplicates the functionality of VisualEditorHooks::onSkinTemplateNavigation()
@@ -987,7 +986,7 @@
 			// If the edit tab is hidden, remove it.
 			if ( !( init.isVisualAvailable ) ) {
 				$caVeEdit.remove();
-			} else if ( pageCanLoadEditor && userCanEditOrViewSource ) {
+			} else if ( pageCanLoadEditor ) {
 				// Allow instant switching to edit mode, without refresh
 				$caVeEdit.off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'visual' ) );
 				// FANDOM change
@@ -1036,11 +1035,11 @@
 				$('.page-side-edit').on('mouseover.ve-target-float', this.preloadModules.bind(this));
 				// FANDOM change
 			}
-			if ( pageCanLoadEditor && userCanEditOrViewSource ) {
+			if ( pageCanLoadEditor ) {
 				// Always bind "Edit source" tab, because we want to handle switching with changes
 				$caEdit.off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'source' ) );
 			}
-			if ( pageCanLoadEditor && init.isWikitextAvailable && userCanEditOrViewSource ) {
+			if ( pageCanLoadEditor && init.isWikitextAvailable ) {
 				// Only bind "Add topic" tab if NWE is available, because VE doesn't support section
 				// so we never have to switch from it when editing a section
 				$( '#ca-addsection' ).off( '.ve-target' ).on( 'click.ve-target', init.onEditTabClick.bind( init, 'source' ) );


### PR DESCRIPTION
**Jira**: https://fandom.atlassian.net/browse/UGC-5375
Related `unified-platform` PR: https://github.com/Wikia/unified-platform/pull/17185

**Changes**:
There are cases when `mainAction` is not present. In most instances, this indicates that the user lacks permissions to edit or view the source of the page. Consequently, we refrain from rendering buttons for editing, and attempts to get them on the client side may fail, resulting in errors when attempting to manipulate non-existent DOM elements.

We have similar checks (here as example https://github.com/Wikia/mediawiki-extensions-VisualEditor/blob/REL1_39/modules/ve-mw/preinit/ve.init.mw.DesktopArticleTarget.init.js#L948-L950), which I believe is an not the best approach to prevent further error triggers, but if it works in this manner, I don't think I can alter it. 😿 
